### PR TITLE
Update larabot config for Python 3

### DIFF
--- a/.larabot.conf
+++ b/.larabot.conf
@@ -1,8 +1,8 @@
 
-compilation = "pip install -r requirements.txt"
+compilation = "pip3 install -r requirements.txt"
 
 commands = [
-    "python -m unittest discover"
+    "python3 -m unittest discover"
 ]
 
 trusted = [


### PR DESCRIPTION
Python 3 is apparently required to run the unit tests.